### PR TITLE
feat: expand hook surface for title, description, social, and schema (PR 1 of 3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [1.5.0] - 2026-04-19
+
+### Added
+- New filters for title, description, and social meta:
+  - `lean_seo_title` — override the resolved SEO title
+  - `lean_seo_document_title` — short-circuit the `<title>` tag (works on the homepage)
+  - `lean_seo_og_title` — override the `og:title` value
+  - `lean_seo_description` — override the resolved description (context-aware)
+  - `lean_seo_og_site_name` — override `og:site_name`
+  - `lean_seo_og_locale` — override `og:locale`
+  - `lean_seo_twitter_handle` — set `@handle` for `twitter:site`
+  - `lean_seo_title_separator` — customize the title separator (default `|`)
+- New filters for schema enrichment:
+  - `lean_seo_website_schema` — modify the WebSite node
+  - `lean_seo_organization_schema` — modify the Organization node (add `sameAs`, etc.)
+  - `lean_seo_person_schema` — opt-in Person node for personal sites
+  - `lean_seo_webpage_schema` — modify the WebPage node
+  - `lean_seo_breadcrumb_schema` — modify the BreadcrumbList node
+  - `lean_seo_schema_graph` — modify the complete `@graph` before output
+- `Lean_SEO_Meta::get_context()` helper exposing the current page context
+  (`home` | `single` | `archive` | `taxonomy` | `search` | `author` | `date` | `404` | `other`).
+
+### Changed
+- `Lean_SEO_Meta::get_description()` now applies `lean_seo_description` after
+  the default fallback chain so themes/plugins can refine the resolved value
+  without rebuilding it from scratch. The legacy `lean_seo_custom_description`
+  filter still short-circuits the chain for backwards compatibility.
+- `pre_get_document_title` is now hooked so `lean_seo_document_title` can
+  override the homepage `<title>` (which `document_title_parts` cannot).
+
+### Fixed
+- BreadcrumbList no longer emits a duplicate `Home → Home` entry on the
+  homepage. The current-page crumb is now skipped when on the front page.
+
 ## [1.2.0] - 2026-02-23
 
 ### Added

--- a/includes/class-lean-seo-meta.php
+++ b/includes/class-lean-seo-meta.php
@@ -17,10 +17,36 @@ class Lean_SEO_Meta {
      */
     public static function output() {
         $description = self::get_description();
-        $image = self::get_image();
-        $url = self::get_url();
-        $site_name = get_bloginfo('name');
-        $title = wp_get_document_title();
+        $image       = self::get_image();
+        $url         = self::get_url();
+        $context     = self::get_context();
+
+        /**
+         * Filter the og:site_name value.
+         *
+         * @since 1.5.0
+         * @param string $site_name Default is get_bloginfo('name').
+         */
+        $site_name = apply_filters('lean_seo_og_site_name', get_bloginfo('name'));
+
+        /**
+         * Filter the og:locale value.
+         *
+         * @since 1.5.0
+         * @param string $locale Default is get_locale().
+         */
+        $locale = apply_filters('lean_seo_og_locale', get_locale());
+
+        $title = self::get_title();
+
+        /**
+         * Filter the og:title value specifically (overrides lean_seo_title for OG).
+         *
+         * @since 1.5.0
+         * @param string $og_title Default is the filtered title.
+         * @param string $context  Current page context (see get_context()).
+         */
+        $og_title = apply_filters('lean_seo_og_title', $title, $context);
 
         // Basic meta description
         if ($description) {
@@ -28,9 +54,9 @@ class Lean_SEO_Meta {
         }
 
         // Open Graph
-        echo '<meta property="og:locale" content="' . esc_attr(get_locale()) . '">' . "\n";
+        echo '<meta property="og:locale" content="' . esc_attr($locale) . '">' . "\n";
         echo '<meta property="og:type" content="' . (is_singular('post') ? 'article' : 'website') . '">' . "\n";
-        echo '<meta property="og:title" content="' . esc_attr($title) . '">' . "\n";
+        echo '<meta property="og:title" content="' . esc_attr($og_title) . '">' . "\n";
 
         if ($description) {
             echo '<meta property="og:description" content="' . esc_attr($description) . '">' . "\n";
@@ -76,7 +102,23 @@ class Lean_SEO_Meta {
 
         // Twitter Card
         echo '<meta name="twitter:card" content="summary_large_image">' . "\n";
-        echo '<meta name="twitter:title" content="' . esc_attr($title) . '">' . "\n";
+
+        /**
+         * Filter the @handle used for twitter:site meta.
+         *
+         * Return a string like '@username' (leading @ is normalized). Return
+         * empty string to omit the tag entirely. Default is empty.
+         *
+         * @since 1.5.0
+         * @param string $handle Default empty string.
+         */
+        $twitter_handle = apply_filters('lean_seo_twitter_handle', '');
+        if ($twitter_handle) {
+            $twitter_handle = '@' . ltrim($twitter_handle, '@');
+            echo '<meta name="twitter:site" content="' . esc_attr($twitter_handle) . '">' . "\n";
+        }
+
+        echo '<meta name="twitter:title" content="' . esc_attr($og_title) . '">' . "\n";
 
         if ($description) {
             echo '<meta name="twitter:description" content="' . esc_attr($description) . '">' . "\n";
@@ -85,6 +127,70 @@ class Lean_SEO_Meta {
         if ($image) {
             echo '<meta name="twitter:image" content="' . esc_url($image) . '">' . "\n";
         }
+    }
+
+    /**
+     * Get the title for the current request, filterable.
+     *
+     * Runs wp_get_document_title() through the lean_seo_title filter so
+     * themes and plugins can override the default without having to hook
+     * every meta output individually. Separate filters still exist for
+     * og:title and the document <title>.
+     *
+     * @since 1.5.0
+     * @return string
+     */
+    public static function get_title() {
+        $title   = wp_get_document_title();
+        $context = self::get_context();
+
+        /**
+         * Filter the resolved SEO title.
+         *
+         * @since 1.5.0
+         * @param string $title   Default is wp_get_document_title().
+         * @param string $context Current page context.
+         */
+        return apply_filters('lean_seo_title', $title, $context);
+    }
+
+    /**
+     * Get a symbolic context string for the current request.
+     *
+     * Used as the $context argument for lean_seo_title / lean_seo_description
+     * filters so callers can branch on page type without re-running conditional
+     * tags themselves.
+     *
+     * @since 1.5.0
+     * @return string One of: 'home' | 'single' | 'archive' | 'taxonomy' |
+     *                'search' | 'author' | 'date' | '404' | 'other'.
+     */
+    public static function get_context() {
+        if (is_home() || is_front_page()) {
+            return 'home';
+        }
+        if (is_singular()) {
+            return 'single';
+        }
+        if (is_post_type_archive()) {
+            return 'archive';
+        }
+        if (is_category() || is_tag() || is_tax()) {
+            return 'taxonomy';
+        }
+        if (is_search()) {
+            return 'search';
+        }
+        if (is_author()) {
+            return 'author';
+        }
+        if (is_date()) {
+            return 'date';
+        }
+        if (is_404()) {
+            return '404';
+        }
+        return 'other';
     }
 
     /**
@@ -99,14 +205,49 @@ class Lean_SEO_Meta {
 
     /**
      * Get meta description
+     *
+     * Resolves the description through the default fallback chain, then
+     * applies the lean_seo_description filter (context-aware) for fine
+     * control. The legacy lean_seo_custom_description filter still runs
+     * first and short-circuits the chain for backwards compatibility.
      */
     public static function get_description() {
-        // Allow themes/plugins to provide custom descriptions
+        // Legacy short-circuit filter (kept for backwards compatibility).
         $custom = apply_filters('lean_seo_custom_description', false);
         if ($custom) {
-            return $custom;
+            $context = self::get_context();
+            /** This filter is documented below. */
+            return apply_filters('lean_seo_description', $custom, $context);
         }
 
+        $description = self::resolve_default_description();
+        $context     = self::get_context();
+
+        /**
+         * Filter the resolved meta description.
+         *
+         * Unlike lean_seo_custom_description (which short-circuits the
+         * fallback chain), this filter runs after the default resolution
+         * and receives a context string so callers can branch on page type
+         * without duplicating conditional logic.
+         *
+         * @since 1.5.0
+         * @param string $description Resolved default description.
+         * @param string $context     Current page context (see get_context()).
+         */
+        return apply_filters('lean_seo_description', $description, $context);
+    }
+
+    /**
+     * Resolve the default description using the built-in fallback chain.
+     *
+     * Separated from get_description() so the lean_seo_description filter
+     * always runs on the final value regardless of which branch supplied it.
+     *
+     * @since 1.5.0
+     * @return string
+     */
+    protected static function resolve_default_description() {
         if (is_singular()) {
             // Custom meta description
             $custom_desc = get_post_meta(get_the_ID(), '_lean_seo_description', true);
@@ -116,13 +257,15 @@ class Lean_SEO_Meta {
 
             // Fall back to excerpt
             $post = get_post();
-            if ($post->post_excerpt) {
+            if ($post && $post->post_excerpt) {
                 return wp_strip_all_tags($post->post_excerpt);
             }
 
             // Fall back to trimmed content
-            $content = wp_strip_all_tags(strip_shortcodes($post->post_content));
-            return wp_trim_words($content, 30, '...');
+            if ($post) {
+                $content = wp_strip_all_tags(strip_shortcodes($post->post_content));
+                return wp_trim_words($content, 30, '...');
+            }
         }
 
         if (is_home() || is_front_page()) {
@@ -143,7 +286,9 @@ class Lean_SEO_Meta {
 
         if (is_author()) {
             $author = get_queried_object();
-            return sprintf('Posts by %s on %s', $author->display_name, get_bloginfo('name'));
+            if ($author) {
+                return sprintf('Posts by %s on %s', $author->display_name, get_bloginfo('name'));
+            }
         }
 
         return get_bloginfo('description');

--- a/includes/class-lean-seo-schema.php
+++ b/includes/class-lean-seo-schema.php
@@ -24,6 +24,12 @@ class Lean_SEO_Schema {
         // Organization schema
         $schema[] = self::get_organization_schema();
 
+        // Person schema — empty by default; themes/plugins populate via filter.
+        $person_schema = self::get_person_schema();
+        if ($person_schema) {
+            $schema[] = $person_schema;
+        }
+
         // Article schema for posts
         if (is_singular('post')) {
             $schema[] = self::get_webpage_schema();
@@ -44,6 +50,18 @@ class Lean_SEO_Schema {
         // Filter empty values
         $schema = array_filter($schema);
 
+        /**
+         * Filter the complete JSON-LD @graph before output.
+         *
+         * Allows adding, removing, or reordering schema nodes. Runs after
+         * individual node filters (lean_seo_website_schema, etc.) so the
+         * graph this filter receives contains each node's final shape.
+         *
+         * @since 1.5.0
+         * @param array $graph Array of schema node arrays.
+         */
+        $schema = apply_filters('lean_seo_schema_graph', $schema);
+
         // Output
         $output = array(
             '@context' => 'https://schema.org',
@@ -59,7 +77,7 @@ class Lean_SEO_Schema {
      * Website schema
      */
     private static function get_website_schema() {
-        return array(
+        $schema = array(
             '@type' => 'WebSite',
             '@id' => home_url('/#website'),
             'url' => home_url('/'),
@@ -74,6 +92,14 @@ class Lean_SEO_Schema {
                 'query-input' => 'required name=search_term_string'
             )
         );
+
+        /**
+         * Filter the WebSite schema node.
+         *
+         * @since 1.5.0
+         * @param array $schema WebSite schema array.
+         */
+        return apply_filters('lean_seo_website_schema', $schema);
     }
 
     /**
@@ -103,7 +129,50 @@ class Lean_SEO_Schema {
             $schema['logo'] = $logo_schema;
         }
 
-        return $schema;
+        /**
+         * Filter the Organization schema node.
+         *
+         * Use this to add sameAs (social URLs), description, founder,
+         * contactPoint, or any other Schema.org Organization properties.
+         *
+         * @since 1.5.0
+         * @param array $schema Organization schema array.
+         */
+        return apply_filters('lean_seo_organization_schema', $schema);
+    }
+
+    /**
+     * Person schema (opt-in via filter).
+     *
+     * Not emitted by default. Sites representing an individual (personal
+     * blogs, author sites) can return a populated Person node via the
+     * lean_seo_person_schema filter and it will be added to the graph.
+     *
+     * @since 1.5.0
+     * @return array|null Person schema array, or null to omit.
+     */
+    private static function get_person_schema() {
+        $default = null;
+
+        /**
+         * Filter the Person schema node.
+         *
+         * Return a Schema.org Person array to include it in the graph,
+         * or null (default) to omit. Typical shape:
+         *
+         *     array(
+         *         '@type'       => 'Person',
+         *         '@id'         => home_url('/#person'),
+         *         'name'        => 'Jane Doe',
+         *         'url'         => home_url('/'),
+         *         'description' => 'Writer, developer, sailor.',
+         *         'sameAs'      => array('https://twitter.com/...', ...),
+         *     )
+         *
+         * @since 1.5.0
+         * @param array|null $schema Default null (omitted).
+         */
+        return apply_filters('lean_seo_person_schema', $default);
     }
 
     /**
@@ -154,7 +223,7 @@ class Lean_SEO_Schema {
      * WebPage schema
      */
     private static function get_webpage_schema() {
-        return array(
+        $schema = array(
             '@type' => 'WebPage',
             '@id' => get_permalink() . '#webpage',
             'url' => get_permalink(),
@@ -163,16 +232,30 @@ class Lean_SEO_Schema {
             'datePublished' => get_the_date('c'),
             'dateModified' => get_the_modified_date('c'),
         );
+
+        /**
+         * Filter the WebPage schema node.
+         *
+         * @since 1.5.0
+         * @param array $schema WebPage schema array.
+         */
+        return apply_filters('lean_seo_webpage_schema', $schema);
     }
 
     /**
      * Breadcrumb schema
+     *
+     * Emits a BreadcrumbList. On the homepage, only a single "Home"
+     * crumb is emitted (the current-page entry is omitted to avoid the
+     * "Home → Home" duplicate — see GitHub issue #2). On singular views,
+     * the home crumb is followed by an optional category (posts) and
+     * the current page title.
      */
     private static function get_breadcrumb_schema() {
         $items = array();
         $position = 1;
 
-        // Home
+        // Home crumb
         $items[] = array(
             '@type' => 'ListItem',
             'position' => $position++,
@@ -194,18 +277,30 @@ class Lean_SEO_Schema {
             }
         }
 
-        // Current page (no item URL for last breadcrumb)
-        $items[] = array(
-            '@type' => 'ListItem',
-            'position' => $position,
-            'name' => get_the_title()
-        );
+        // Current page (singular only — the homepage is already "Home").
+        // Last crumb intentionally omits the item URL per BreadcrumbList
+        // best practices.
+        if (is_singular() && ! is_front_page() && ! is_home()) {
+            $items[] = array(
+                '@type' => 'ListItem',
+                'position' => $position,
+                'name' => get_the_title()
+            );
+        }
 
-        return array(
+        $schema = array(
             '@type' => 'BreadcrumbList',
-            '@id' => get_permalink() . '#breadcrumb',
+            '@id' => ((is_front_page() || is_home()) ? home_url('/') : get_permalink()) . '#breadcrumb',
             'itemListElement' => $items
         );
+
+        /**
+         * Filter the BreadcrumbList schema node.
+         *
+         * @since 1.5.0
+         * @param array $schema Breadcrumb schema array.
+         */
+        return apply_filters('lean_seo_breadcrumb_schema', $schema);
     }
 
     /**

--- a/includes/class-lean-seo.php
+++ b/includes/class-lean-seo.php
@@ -50,6 +50,7 @@ class Lean_SEO {
      */
     private function init_hooks() {
         // Meta tags
+        add_filter('pre_get_document_title', array($this, 'filter_document_title'), 10);
         add_filter('document_title_parts', array($this, 'filter_title_parts'), 10);
         add_filter('document_title_separator', array($this, 'title_separator'));
         add_action('wp_head', array($this, 'output_meta_tags'), 1);
@@ -119,6 +120,37 @@ class Lean_SEO {
     }
 
     /**
+     * Short-circuit the document <title> tag entirely.
+     *
+     * Returning a non-empty string here bypasses WordPress core's title
+     * assembly. We only act if a filter callback provides a value via
+     * the `lean_seo_document_title` filter, letting themes/site-specific
+     * plugins set the homepage title or override any context without
+     * rebuilding the full fallback chain.
+     *
+     * @since 1.5.0
+     * @param string $title Current title (empty string by default).
+     * @return string
+     */
+    public function filter_document_title($title) {
+        /**
+         * Filter the final <title> tag output.
+         *
+         * Return a non-empty string to replace WordPress's document title
+         * entirely. Return empty (default) to let core + lean_seo build
+         * the title normally. This is the only filter that can override
+         * the homepage title without touching the theme.
+         *
+         * @since 1.5.0
+         * @param string $title   Empty by default; override with a string to short-circuit.
+         * @param string $context Current page context (see Lean_SEO_Meta::get_context()).
+         */
+        $override = apply_filters('lean_seo_document_title', '', Lean_SEO_Meta::get_context());
+
+        return $override !== '' ? $override : $title;
+    }
+
+    /**
      * Filter document title parts
      */
     public function filter_title_parts($title) {
@@ -133,9 +165,18 @@ class Lean_SEO {
 
     /**
      * Title separator
+     *
+     * @since 1.0.0
+     * @since 1.5.0 Made filterable via lean_seo_title_separator.
      */
     public function title_separator($sep) {
-        return '|';
+        /**
+         * Filter the separator used in the document title.
+         *
+         * @since 1.5.0
+         * @param string $separator Default '|'.
+         */
+        return apply_filters('lean_seo_title_separator', '|');
     }
 
     /**

--- a/lean-seo.php
+++ b/lean-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: Lean SEO
  * Plugin URI: https://github.com/Sarai-Chinwag/lean-seo
  * Description: Lightweight SEO without the bloat. Meta tags, Open Graph, Schema markup, XML sitemaps, and per-post SEO fields. A Yoast replacement that doesn't slow your site down.
- * Version: 1.4.0
+ * Version: 1.5.0
  * Author: Sarai Chinwag
  * Author URI: https://saraichinwag.com
  * License: GPL-2.0+
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('LEAN_SEO_VERSION', '1.4.0');
+define('LEAN_SEO_VERSION', '1.5.0');
 define('LEAN_SEO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('LEAN_SEO_PLUGIN_URL', plugin_dir_url(__FILE__));
 


### PR DESCRIPTION
First of three PRs from #2. Pure filter additions and one bug fix — no UI, no breaking changes.

## What's new

### Title control
- \`lean_seo_title\` — override the resolved SEO title
- \`lean_seo_document_title\` — short-circuit the \`<title>\` tag entirely (the only filter that can override the homepage title without touching the theme)
- \`lean_seo_og_title\` — override the \`og:title\` value
- \`lean_seo_title_separator\` — customize the title separator (default \`|\`)

### Description
- \`lean_seo_description\` — override the resolved description, context-aware
- Legacy \`lean_seo_custom_description\` still short-circuits the chain for backwards compatibility

### Social config
- \`lean_seo_og_site_name\` — override \`og:site_name\`
- \`lean_seo_og_locale\` — override \`og:locale\`
- \`lean_seo_twitter_handle\` — set \`@handle\` for \`twitter:site\` (handles leading-@ normalization)

### Schema enrichment
- \`lean_seo_website_schema\` — modify the WebSite node
- \`lean_seo_organization_schema\` — modify the Organization node (add \`sameAs\`, etc.)
- \`lean_seo_person_schema\` — opt-in Person node for personal sites (omitted by default)
- \`lean_seo_webpage_schema\` — modify the WebPage node
- \`lean_seo_breadcrumb_schema\` — modify the BreadcrumbList node
- \`lean_seo_schema_graph\` — modify the complete \`@graph\` before output

### Helper
- \`Lean_SEO_Meta::get_context()\` exposes \`home | single | archive | taxonomy | search | author | date | 404 | other\` so callers branch on page type without re-running conditional tags. Used as the \`\$context\` arg for \`lean_seo_title\` / \`lean_seo_description\` filters.

## Bug fix

BreadcrumbList no longer emits a duplicate \`Home → Home\` entry on the homepage. The current-page crumb is now skipped on front-page/home views, and the schema \`@id\` correctly uses the home URL instead of the (empty) permalink.

## Verification

Tested end-to-end on a live MySQL site (chubes.net, 1,300+ posts). With:

\`\`\`php
add_filter('lean_seo_document_title', fn(\$t, \$ctx) => \$ctx === 'home' ? 'Chris Huber - Developer & Music Journalist' : '', 10, 2);
add_filter('lean_seo_twitter_handle', fn() => 'chubes4');
add_filter('lean_seo_person_schema', fn() => [
    '@type' => 'Person',
    '@id'   => home_url('/#person'),
    'name'  => 'Chris Huber',
    'url'   => home_url('/'),
    'sameAs'=> ['https://x.com/chubes4', 'https://github.com/chubes4'],
]);
\`\`\`

- ✅ Homepage \`<title>\` overrides correctly
- ✅ \`twitter:site\` outputs as \`@chubes4\`
- ✅ Person node appears in JSON-LD graph
- ✅ Breadcrumb shows single \`Home\` (no duplicate)
- ✅ All other meta tags render unchanged

PHP syntax check passes on all modified files.

## Backwards compatibility

- All new filters default to current behavior
- \`lean_seo_custom_description\` continues to work as before
- No existing meta box, sitemap, or admin behavior touched
- The breadcrumb fix is the only output change; sites relying on the duplicate \`Home → Home\` (none should) would notice

## Up next (separate PRs)

- PR 2: Site identity settings UI (Person/Organization, social URLs, default OG image, Twitter handle) that consumes these filters
- PR 3: Homepage SEO settings (title/description with template variables)

Refs #2.