### PR TITLE
chore: add homeboy.json for version and release management

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,0 +1,19 @@
+{
+  "auto_cleanup": false,
+  "changelog_target": "docs/CHANGELOG.md",
+  "extensions": {
+    "wordpress": {}
+  },
+  "id": "lean-seo",
+  "remote_path": "wp-content/plugins/lean-seo",
+  "version_targets": [
+    {
+      "file": "lean-seo.php",
+      "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "lean-seo.php",
+      "pattern": "LEAN_SEO_VERSION',\\s*'([0-9.]+)'"
+    }
+  ]
+}


### PR DESCRIPTION
Registers lean-seo as a [Homeboy](https://github.com/Extra-Chill/homeboy) component. Homeboy is Extra Chill's release automation tool — with this config, \`homeboy version bump\` handles both version locations automatically, and \`homeboy release\` can publish full releases including build + GitHub release creation.

## What this adds

A single \`homeboy.json\` at the repo root:

\`\`\`json
{
  "auto_cleanup": false,
  "changelog_target": "docs/CHANGELOG.md",
  "extensions": { "wordpress": {} },
  "id": "lean-seo",
  "remote_path": "wp-content/plugins/lean-seo",
  "version_targets": [
    {
      "file": "lean-seo.php",
      "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
    },
    {
      "file": "lean-seo.php",
      "pattern": "LEAN_SEO_VERSION',\\s*'([0-9.]+)'"
    }
  ]
}
\`\`\`

## Why

The plugin currently needs manual edits in two places per release (header + constant). The PRs from #2 each bump the version — I did it by hand, and it's exactly the kind of error-prone step version automation is for.

Also means lean-seo is now visible to any dev using homeboy for multi-project management (e.g. deploying across sites with \`homeboy deploy\`).

## Verification

\`\`\`
$ homeboy component show lean-seo
{ "success": true, ... "id": "lean-seo", "version_targets": [...] }

$ homeboy version show lean-seo
{ "success": true, ... "version": "1.4.0" }
\`\`\`

Both version targets match exactly once — no ambiguity.

## Not in scope

- GitHub Actions release workflow (can be added later)
- Build automation (plugin has no JS/PHP build step — \`build/lean-seo.zip\` is a simple archive)
- Deploy config (project-specific, users configure locally)

Standalone chore — does not depend on #3/#4/#5.