### PR TITLE
feat: homepage SEO settings with template variables (was PR #5)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.7.0] - 2026-04-19
+
+### Added
+- **Homepage SEO** settings section under Settings → Lean SEO:
+  - Custom homepage title (text field with template-variable support)
+  - Custom homepage meta description (textarea)
+- Template variables supported in homepage title/description:
+  - `%%sitename%%` → site name
+  - `%%tagline%%` → site tagline
+  - `%%sep%%` → title separator (respects `lean_seo_title_separator`)
+- `Lean_SEO_Homepage_Applier` wires settings into filters from 1.5.0:
+  - `lean_seo_document_title` ← homepage title when context is `home`
+  - `lean_seo_description` ← homepage description when context is `home`
+    (only when the default resolution would return an empty value or the
+    generic blog tagline — explicit per-page descriptions still win)
+
+### Changed
+- No behavior changes when homepage settings are empty — the plugin
+  continues to defer to WordPress defaults.
+
 ## [1.6.0] - 2026-04-19
 
 ### Added

--- a/includes/class-lean-seo-homepage.php
+++ b/includes/class-lean-seo-homepage.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Homepage SEO Settings + Applier
+ *
+ * UI for setting a custom homepage title and meta description, plus the
+ * applier that feeds those values into the lean_seo_document_title and
+ * lean_seo_description filters (added in 1.5.0).
+ *
+ * Supports a minimal template-variable system so Yoast converts feel at
+ * home: %%sitename%%, %%tagline%%, %%sep%%.
+ *
+ * @package Lean_SEO
+ * @since 1.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Lean_SEO_Homepage {
+
+    /**
+     * Option key storing homepage SEO settings.
+     *
+     * @var string
+     */
+    const OPTION_KEY = 'lean_seo_homepage';
+
+    /**
+     * Get homepage settings with defaults applied.
+     *
+     * @return array
+     */
+    public static function get_settings() {
+        $saved = get_option( self::OPTION_KEY, array() );
+
+        $defaults = array(
+            'title'       => '',
+            'description' => '',
+        );
+
+        return wp_parse_args( $saved, $defaults );
+    }
+
+    /**
+     * Register settings, section, and fields.
+     *
+     * Called from Lean_SEO_Admin::register_settings.
+     */
+    public static function register() {
+        register_setting( 'lean_seo_settings', self::OPTION_KEY, array(
+            'type'              => 'array',
+            'sanitize_callback' => array( __CLASS__, 'sanitize' ),
+            'default'           => array(),
+        ) );
+
+        add_settings_section(
+            'lean_seo_homepage_section',
+            __( 'Homepage SEO', 'lean-seo' ),
+            function () {
+                echo '<p>' . esc_html__( 'Customize the title and meta description for the homepage. Leave blank to use WordPress defaults.', 'lean-seo' ) . '</p>';
+                echo '<p><strong>' . esc_html__( 'Available variables:', 'lean-seo' ) . '</strong> ';
+                echo '<code>%%sitename%%</code>, <code>%%tagline%%</code>, <code>%%sep%%</code></p>';
+            },
+            'lean_seo_settings'
+        );
+
+        add_settings_field(
+            'lean_seo_homepage_title',
+            __( 'Homepage Title', 'lean-seo' ),
+            array( __CLASS__, 'render_title_field' ),
+            'lean_seo_settings',
+            'lean_seo_homepage_section'
+        );
+
+        add_settings_field(
+            'lean_seo_homepage_description',
+            __( 'Homepage Description', 'lean-seo' ),
+            array( __CLASS__, 'render_description_field' ),
+            'lean_seo_settings',
+            'lean_seo_homepage_section'
+        );
+    }
+
+    /**
+     * Render the homepage title input.
+     */
+    public static function render_title_field() {
+        $settings = self::get_settings();
+        $value    = $settings['title'];
+        ?>
+        <input
+            type="text"
+            name="<?php echo esc_attr( self::OPTION_KEY ); ?>[title]"
+            id="lean_seo_homepage_title"
+            value="<?php echo esc_attr( $value ); ?>"
+            class="large-text"
+            placeholder="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>"
+        >
+        <p class="description">
+            <?php esc_html_e( 'Recommended: 50-60 characters. Leave blank to use the site name.', 'lean-seo' ); ?>
+        </p>
+        <?php
+    }
+
+    /**
+     * Render the homepage description textarea.
+     */
+    public static function render_description_field() {
+        $settings = self::get_settings();
+        $value    = $settings['description'];
+        ?>
+        <textarea
+            name="<?php echo esc_attr( self::OPTION_KEY ); ?>[description]"
+            id="lean_seo_homepage_description"
+            rows="3"
+            class="large-text"
+            maxlength="300"
+            placeholder="<?php echo esc_attr( get_bloginfo( 'description' ) ); ?>"
+        ><?php echo esc_textarea( $value ); ?></textarea>
+        <p class="description">
+            <?php esc_html_e( 'Recommended: 150-160 characters. Appears in search results and social shares for the homepage.', 'lean-seo' ); ?>
+        </p>
+        <?php
+    }
+
+    /**
+     * Sanitize homepage settings on save.
+     *
+     * @param array $input Raw input.
+     * @return array
+     */
+    public static function sanitize( $input ) {
+        $clean = array();
+
+        $clean['title']       = isset( $input['title'] ) ? sanitize_text_field( $input['title'] ) : '';
+        $clean['description'] = isset( $input['description'] ) ? sanitize_textarea_field( $input['description'] ) : '';
+
+        return $clean;
+    }
+
+    /**
+     * Expand template variables in a string.
+     *
+     * Supported placeholders:
+     *   %%sitename%% — get_bloginfo('name')
+     *   %%tagline%%  — get_bloginfo('description')
+     *   %%sep%%      — lean_seo_title_separator (default '|')
+     *
+     * Collapses any resulting runs of whitespace so patterns like
+     * "%%sitename%% %%sep%% %%tagline%%" render cleanly even when a
+     * variable resolves to an empty string.
+     *
+     * @param string $template Raw template string.
+     * @return string
+     */
+    public static function expand_variables( $template ) {
+        if ( '' === $template ) {
+            return '';
+        }
+
+        $separator = apply_filters( 'lean_seo_title_separator', '|' );
+
+        $replacements = array(
+            '%%sitename%%' => get_bloginfo( 'name' ),
+            '%%tagline%%'  => get_bloginfo( 'description' ),
+            '%%sep%%'      => $separator,
+        );
+
+        $output = strtr( $template, $replacements );
+
+        // Collapse whitespace from empty replacements.
+        $output = preg_replace( '/\s+/', ' ', $output );
+
+        return trim( $output );
+    }
+}
+
+/**
+ * Homepage Applier
+ *
+ * Reads Lean_SEO_Homepage settings and populates the title/description
+ * filters when the current context is the homepage.
+ *
+ * @since 1.7.0
+ */
+class Lean_SEO_Homepage_Applier {
+
+    /**
+     * Register filter hooks.
+     */
+    public static function register() {
+        add_filter( 'lean_seo_document_title', array( __CLASS__, 'filter_document_title' ), 10, 2 );
+        add_filter( 'lean_seo_description',    array( __CLASS__, 'filter_description' ),    10, 2 );
+    }
+
+    /**
+     * Return the configured homepage title when appropriate.
+     *
+     * Only acts on the homepage context, and only when another callback
+     * hasn't already provided an override.
+     *
+     * @param string $title   Existing override (empty by default).
+     * @param string $context Current page context.
+     * @return string
+     */
+    public static function filter_document_title( $title, $context ) {
+        if ( '' !== $title ) {
+            return $title;
+        }
+        if ( 'home' !== $context ) {
+            return $title;
+        }
+
+        $settings = Lean_SEO_Homepage::get_settings();
+        if ( '' === $settings['title'] ) {
+            return $title;
+        }
+
+        return Lean_SEO_Homepage::expand_variables( $settings['title'] );
+    }
+
+    /**
+     * Return the configured homepage description when appropriate.
+     *
+     * Acts on home context. Runs after the default resolution so any
+     * callback earlier in the chain still takes priority.
+     *
+     * @param string $description Resolved description.
+     * @param string $context     Current page context.
+     * @return string
+     */
+    public static function filter_description( $description, $context ) {
+        if ( 'home' !== $context ) {
+            return $description;
+        }
+
+        $settings = Lean_SEO_Homepage::get_settings();
+        if ( '' === $settings['description'] ) {
+            return $description;
+        }
+
+        // Only override when the default description is empty or falls back
+        // to the blog tagline. Sites that explicitly wire their own home
+        // description via filter still win because a non-empty, non-tagline
+        // value means something intentional is already there.
+        $tagline = (string) get_bloginfo( 'description' );
+        if ( '' !== $description && $description !== $tagline ) {
+            return $description;
+        }
+
+        return Lean_SEO_Homepage::expand_variables( $settings['description'] );
+    }
+}

--- a/includes/class-lean-seo.php
+++ b/includes/class-lean-seo.php
@@ -44,6 +44,7 @@ class Lean_SEO {
         require_once LEAN_SEO_PLUGIN_DIR . 'includes/class-lean-seo-schema.php';
         require_once LEAN_SEO_PLUGIN_DIR . 'includes/class-lean-seo-admin.php';
         require_once LEAN_SEO_PLUGIN_DIR . 'includes/class-lean-seo-identity.php';
+        require_once LEAN_SEO_PLUGIN_DIR . 'includes/class-lean-seo-homepage.php';
     }
 
     /**
@@ -76,11 +77,13 @@ class Lean_SEO {
             add_action('admin_menu', array('Lean_SEO_Admin', 'add_settings_page'));
             add_action('admin_init', array('Lean_SEO_Admin', 'register_settings'));
             add_action('admin_init', array('Lean_SEO_Identity', 'register'));
+            add_action('admin_init', array('Lean_SEO_Homepage', 'register'));
             add_action('admin_enqueue_scripts', array('Lean_SEO_Identity', 'enqueue_assets'));
         }
 
-        // Identity filters run everywhere (front-end + admin previews).
+        // Filter appliers run everywhere (front-end + admin previews).
         Lean_SEO_Identity_Applier::register();
+        Lean_SEO_Homepage_Applier::register();
 
         // Filter robots.txt to include our sitemap
         add_filter('robots_txt', array($this, 'filter_robots_txt'), 999, 2);

--- a/lean-seo.php
+++ b/lean-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: Lean SEO
  * Plugin URI: https://github.com/Sarai-Chinwag/lean-seo
  * Description: Lightweight SEO without the bloat. Meta tags, Open Graph, Schema markup, XML sitemaps, and per-post SEO fields. A Yoast replacement that doesn't slow your site down.
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: Sarai Chinwag
  * Author URI: https://saraichinwag.com
  * License: GPL-2.0+
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-define('LEAN_SEO_VERSION', '1.6.0');
+define('LEAN_SEO_VERSION', '1.7.0');
 define('LEAN_SEO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('LEAN_SEO_PLUGIN_URL', plugin_dir_url(__FILE__));
 


### PR DESCRIPTION
Re-opening after #7 merged — original PR #5 was auto-closed when its base branch was deleted. Same code, rebased onto current main.

---

Adds UI for homepage title and meta description with a minimal template-variable system (`%%sitename%%`, `%%tagline%%`, `%%sep%%`). Wires stored values into `lean_seo_document_title` and `lean_seo_description` filters.

See original PR #5 for full design rationale: https://github.com/Sarai-Chinwag/lean-seo/pull/5

Completes the three-PR stack from #2.

Refs #2.